### PR TITLE
Allow Mongo null dates

### DIFF
--- a/lib/Utilities/MongoTrait.php
+++ b/lib/Utilities/MongoTrait.php
@@ -23,6 +23,10 @@ trait MongoTrait
 		};
 
 		$ext_callable = function ($date) {
+			if (empty($date)) {
+				return null;
+			}
+
 			$date = $date instanceof \DateTime ? $date->getTimestamp() : strtotime($date);
 
 			return new MongoDate($date);

--- a/tests/Utilities/MongoTest.php
+++ b/tests/Utilities/MongoTest.php
@@ -25,6 +25,8 @@ class MongoTest extends \PHPUnit_Framework_TestCase
 	public function testDateToExtNull()
 	{
 		$this->assertNull($this->transformer->toExt(null, 'app_date'));
+
+		$this->assertEquals(['ext_date' => null], $this->transformer->toExt(['app_date' => null]));
 	}
 
 	public function testDateToApp()


### PR DESCRIPTION
Allow Mongo toExt() to pass through dates as null, vs converting to empty MongoDate(); 
Add unit test for null dates within an assoc array