### PR TITLE
Fix conversion of UTCDateTime to DateTime

### DIFF
--- a/lib/Utilities/MongoDBTrait.php
+++ b/lib/Utilities/MongoDBTrait.php
@@ -23,7 +23,12 @@ trait MongoDBTrait
 	protected function defineDate($app_name, $ext_name)
 	{
 		$app_callable = function ($date) {
-			return $date instanceof UTCDateTime ? $date->toDateTime() : null;
+			if ($date instanceof UTCDateTime) {
+				// NOTE: Generates new DateTime to workaround issue with unserialize
+				// of UTCDateTime::toDateTime() object
+				return new \DateTime('@' . $date->toDateTime()->getTimestamp());
+			}
+			return null;
 		};
 
 		$ext_callable = function ($date) {


### PR DESCRIPTION
Don't return UTCDateTime->getDateTime() directly, as doesn't unserialize correctly.

See: https://github.com/mongodb/mongo-php-driver/issues/262